### PR TITLE
Fixed default server for local vagrant installations

### DIFF
--- a/createTasks.py
+++ b/createTasks.py
@@ -35,8 +35,8 @@ def handle_arguments():
     parser = OptionParser(usage)
     # URL where PyBossa listens
     parser.add_option("-s", "--server", dest="api_url",
-                      help="PyBossa URL http://domain.com/", metavar="URL",
-                      default="http://localhost:5000/")
+                      help="PyBossa URL http://domain.com", metavar="URL",
+                      default="http://localhost:5000")
     # API-KEY
     parser.add_option("-k", "--api-key", dest="api_key",
                       help="PyBossa User API-KEY to interact with PyBossa",


### PR DESCRIPTION
Hi @teleyinex,

I have installed locally the pybossa server through vagrant and I was following up the step-by-step tutorial for the flickrperson app. 

I have tried to create the app but did not work, looking into the Exceptio I've got I realised that the default server was not defined correctly because of the ending slash.

```
python createTasks.py  -k API-KEY -s http://localhost:5000/ -c
```

Did not work, but

```
python createTasks.py -k API-KEY -s http://localhost:5000 -c
```

Did work.

So I have just removed the ending slash and the help example as well

Cheers

Juan
